### PR TITLE
Added support for return 'en' in non-supported locales. #16

### DIFF
--- a/library/iyzico-for-woocommerce-gateway-helper.php
+++ b/library/iyzico-for-woocommerce-gateway-helper.php
@@ -51,7 +51,11 @@ class Iyzico_Checkout_For_WooCommerce_Helper {
 
 		$locale = explode('_',$locale);
 		$locale = $locale[0];
-
+		// Check for support locales and return 'en' for non supported locales
+		$supported_locals = ['en', 'tr'];
+		if( !in_array($locale, $supported_locals) ){
+			return 'en';
+		}
 		return $locale;
 	}
 

--- a/media/css/iyzico.css
+++ b/media/css/iyzico.css
@@ -26,3 +26,7 @@
     -webkit-transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg);
   }
 }
+
+.iyzi-form.responsive {
+    direction: ltr;
+}


### PR DESCRIPTION
As iyzipay not supporting locales other than 'English' or 'Turkish' we need to load form in default language(English) for other locale websites. related to #16 