### PR TITLE
ISSUE #39 FIX

### DIFF
--- a/includes/Common/Helpers/DataFactory.php
+++ b/includes/Common/Helpers/DataFactory.php
@@ -116,7 +116,7 @@ class DataFactory {
 			$shippingItem->setName( 'Shipping' );
 			$shippingItem->setCategory1( 'Shipping' );
 			$shippingItem->setItemType( BasketItemType::PHYSICAL );
-			$shippingPrice = strval( floatval( $order->get_shipping_total() ) + floatval( $order->get_shipping_tax() ) );
+            $shippingPrice = strval( round(floatval( $order->get_shipping_total() ) + floatval( $order->get_shipping_tax() ), 2) );
 			$shippingItem->setPrice( $shippingPrice );
 			$basketItems[] = $shippingItem;
 		}


### PR DESCRIPTION
Benim gibi döviz kurları ile shipment fiyatını belirleyen WooCommerce mağazalarının taşıma fiyatları uzun ondalık sayılardan oluşabiliyor. Ondalık hanesi 2'den fazla olduğunda ise aşağıdaki hata meydana geliyor.

"Gönderilen tutar tüm kırılımların toplam tutarına eşit olmalıdır" #39 

Bu durum ilk olarak kargo fiyatının intval olarak ayarlanmasıyla ortaya çıkmıştı. O hatayı floatval olarak güncelleme düzeltilmesine karşın fiyat 2'den fazla ondalık basamak içeriyorsa yine hataya sebebiyet veriyordu. Bu durumu düzeltmek için `round(SHIPMENT_FEE, 2)` çözümü uyguladım. Benim gibi mağdur olan kişilerin dertlerini çözecektir.